### PR TITLE
Add location input with geolocation

### DIFF
--- a/components/RTCForm.js
+++ b/components/RTCForm.js
@@ -14,6 +14,9 @@ export default function RTCForm() {
     ownerName: '',
     insuranceCompany: '',
     policyNo: '',
+    location: '',
+    lat: '',
+    lng: '',
     injuries: 'No',
     injuryDetails: '',
     officer: '',
@@ -30,6 +33,24 @@ export default function RTCForm() {
   const handleChange = (e) => {
     const { name, value } = e.target;
     setFormData(prev => ({ ...prev, [name]: value }));
+  };
+
+  const handleUseLocation = () => {
+    if (!navigator.geolocation) {
+      alert('Geolocation is not supported by your browser');
+      return;
+    }
+    navigator.geolocation.getCurrentPosition(
+      (pos) => {
+        const { latitude, longitude } = pos.coords;
+        setFormData(prev => ({
+          ...prev,
+          lat: latitude.toFixed(6),
+          lng: longitude.toFixed(6),
+        }));
+      },
+      () => alert('Unable to retrieve your location')
+    );
   };
 
   const handleSubmit = async (e) => {
@@ -149,6 +170,48 @@ export default function RTCForm() {
           />
         </div>
       </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4 items-end">
+        <div>
+          <label className="block font-medium">Location of Collision:</label>
+          <input
+            type="text"
+            name="location"
+            value={formData.location}
+            onChange={handleChange}
+            placeholder="Enter street or area"
+            className="mt-1 block w-full p-2 border rounded"
+          />
+        </div>
+        <button
+          type="button"
+          onClick={handleUseLocation}
+          className="px-4 py-2 rounded-full bg-gray-200 dark:bg-gray-700"
+        >
+          Use My Location
+        </button>
+      </div>
+      {formData.lat && formData.lng && (
+        <div className="mt-2">
+          <iframe
+            title="map"
+            width="100%"
+            height="300"
+            className="border rounded"
+            src={`https://www.openstreetmap.org/export/embed.html?bbox=${formData.lng - 0.005},${formData.lat - 0.005},${formData.lng + 0.005},${formData.lat + 0.005}&layer=mapnik&marker=${formData.lat},${formData.lng}`}
+          />
+          <p className="text-sm mt-1">
+            <a
+              href={`https://www.openstreetmap.org/?mlat=${formData.lat}&mlon=${formData.lng}#map=18/${formData.lat}/${formData.lng}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-blue-600 underline"
+            >
+              View on OpenStreetMap
+            </a>
+          </p>
+        </div>
+      )}
 
       <div>
         <label className="block font-medium">Injuries:</label>

--- a/pages/rtc/[id].js
+++ b/pages/rtc/[id].js
@@ -80,19 +80,46 @@ export default function RTCView() {
           )}
           <p>
             <span className="font-medium">Injuries:</span>{' '}
-            {value.injuries}
+          {value.injuries}
+        </p>
+        {value.injuries === 'Yes' && (
+          <p className="italic">
+            <span className="font-medium">Details:</span>{' '}
+            {value.injuryDetails}
           </p>
-          {value.injuries === 'Yes' && (
-            <p className="italic">
-              <span className="font-medium">Details:</span>{' '}
-              {value.injuryDetails}
+        )}
+        {value.location && (
+          <p>
+            <span className="font-medium">Location:</span>{' '}
+            {value.location}
+          </p>
+        )}
+        {value.lat && value.lng && (
+          <div className="mt-2">
+            <iframe
+              title="map"
+              width="100%"
+              height="300"
+              className="border rounded"
+              src={`https://www.openstreetmap.org/export/embed.html?bbox=${value.lng - 0.005},${value.lat - 0.005},${value.lng + 0.005},${value.lat + 0.005}&layer=mapnik&marker=${value.lat},${value.lng}`}
+            />
+            <p className="text-sm mt-1">
+              <a
+                href={`https://www.openstreetmap.org/?mlat=${value.lat}&mlon=${value.lng}#map=18/${value.lat}/${value.lng}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-blue-600 underline"
+              >
+                View on OpenStreetMap
+              </a>
             </p>
-          )}
-          {value.officer && (
-            <p>
-              <span className="font-medium">Officer Dealing:</span>{' '}
-              {value.officer}
-            </p>
+          </div>
+        )}
+        {value.officer && (
+          <p>
+            <span className="font-medium">Officer Dealing:</span>{' '}
+            {value.officer}
+          </p>
           )}
         </div>
 


### PR DESCRIPTION
## Summary
- add location information to RTC form including geolocation button
- display submitted location and map on RTC view page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852fdc18bc88324bde3e6d9558283a2