### PR TITLE
Add crash report email system

### DIFF
--- a/pages/admin/index.js
+++ b/pages/admin/index.js
@@ -1,0 +1,98 @@
+import { useState } from 'react';
+import { collection, doc, updateDoc } from 'firebase/firestore';
+import { useCollection, useCollectionData } from 'react-firebase-hooks/firestore';
+import { db } from '@/firebase/client';
+import Header from '@/components/Header';
+
+function IncidentRow({ id }) {
+  const submissionsRef = collection(db, 'rtc', id, 'submissions');
+  const [submissions] = useCollectionData(submissionsRef, { idField: 'id' });
+  const [expanded, setExpanded] = useState(false);
+
+  const saveSubmission = async (sub) => {
+    const { id: subId, ...data } = sub;
+    await updateDoc(doc(db, 'rtc', id, 'submissions', subId), data);
+  };
+
+  const sendSummary = async () => {
+    await fetch(`/api/final-summary?id=${id}`, { method: 'POST' });
+  };
+
+  return (
+    <div className="border p-4 rounded mb-4">
+      <div className="flex justify-between items-center">
+        <h2 className="text-lg font-medium">Incident {id}</h2>
+        <div className="space-x-2">
+          <span>{submissions ? submissions.length : 0}/5 submissions</span>
+          <button onClick={() => setExpanded(!expanded)} className="px-2 py-1 bg-gray-200 rounded">
+            {expanded ? 'Hide' : 'View'}
+          </button>
+          <button onClick={sendSummary} className="px-2 py-1 bg-blue-600 text-white rounded">
+            Send Final Summary Email
+          </button>
+        </div>
+      </div>
+      {expanded && submissions && (
+        <div className="mt-4 space-y-4">
+          {submissions.map(sub => (
+            <SubmissionForm key={sub.id} incidentId={id} submission={sub} onSave={saveSubmission} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function SubmissionForm({ incidentId, submission, onSave }) {
+  const [form, setForm] = useState(submission);
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setForm(prev => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    await onSave(form);
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="p-2 border rounded space-y-2">
+      <div>
+        <label className="block text-sm font-medium">Full Name</label>
+        <input name="fullName" value={form.fullName} onChange={handleChange} className="w-full p-1 border rounded" />
+      </div>
+      <div>
+        <label className="block text-sm font-medium">Email</label>
+        <input name="email" value={form.email} onChange={handleChange} className="w-full p-1 border rounded" />
+      </div>
+      <div>
+        <label className="block text-sm font-medium">Constable</label>
+        <input name="constable" value={form.constable} onChange={handleChange} className="w-full p-1 border rounded" />
+      </div>
+      <div>
+        <label className="block text-sm font-medium">Location</label>
+        <input name="location" value={form.location} onChange={handleChange} className="w-full p-1 border rounded" />
+      </div>
+      <button type="submit" className="px-2 py-1 bg-green-600 text-white rounded">Save</button>
+    </form>
+  );
+}
+
+export default function AdminPage() {
+  const [incidentsSnapshot] = useCollection(collection(db, 'rtc'));
+  if (!incidentsSnapshot) {
+    return <p className="p-4">Loading…</p>;
+  }
+  return (
+    <div className="min-h-screen bg-white dark:bg-black text-black dark:text-white">
+      <Header />
+      <main className="p-4 max-w-3xl mx-auto">
+        <h1 className="text-2xl mb-4">RTC Admin</h1>
+        {incidentsSnapshot.docs.map(docSnap => (
+          <IncidentRow key={docSnap.id} id={docSnap.id} />
+        ))}
+      </main>
+    </div>
+  );
+}

--- a/pages/api/final-summary.js
+++ b/pages/api/final-summary.js
@@ -1,0 +1,86 @@
+import { Resend } from 'resend';
+import { initializeApp, getApps } from 'firebase/app';
+import { getFirestore, collection, getDocs } from 'firebase/firestore';
+
+const resend = new Resend(process.env.RESEND_API_KEY);
+
+const firebaseConfig = {
+  apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
+  authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
+  projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
+};
+
+if (!getApps().length) initializeApp(firebaseConfig);
+const db = getFirestore();
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') return res.status(405).end();
+
+  const { id } = req.query; // incident number
+  const { officerEmail } = req.body || {};
+
+  try {
+    const snap = await getDocs(collection(db, 'rtc', id, 'submissions'));
+    const submissions = snap.docs.map(d => ({ id: d.id, ...d.data() }));
+
+    if (!submissions.length) return res.status(404).json({ error: 'No submissions' });
+
+    const emails = submissions.map(s => s.email);
+    if (officerEmail) emails.push(officerEmail);
+
+    const html = generateSummaryTemplate(id, submissions);
+
+    await resend.emails.send({
+      from: 'Police Scotland <noreply@resend.dev>',
+      to: emails,
+      subject: `Crash Report Summary - ${id}`,
+      html
+    });
+
+    res.status(200).json({ success: true });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: err.message });
+  }
+}
+
+function generateSummaryTemplate(incidentNumber, submissions) {
+  const parties = submissions
+    .map((s, idx) => {
+      const vehicle = s.vehicle || {};
+      const insurance = s.insurance || {};
+      return `
+      <div style="margin-bottom:20px;">
+        <h3 style="margin:0 0 8px 0;">Party ${idx + 1}</h3>
+        <p><strong>Name:</strong> ${s.fullName}</p>
+        <p><strong>Email:</strong> ${s.email}</p>
+        ${s.phone ? `<p><strong>Phone:</strong> ${s.phone}</p>` : ''}
+        <p><strong>Vehicle:</strong> ${vehicle.make || ''} ${vehicle.model || ''} (${vehicle.colour || ''}) - ${vehicle.reg || ''}</p>
+        <p><strong>Insurance:</strong> ${insurance.company || ''} - Policy ${insurance.policyNumber || ''}</p>
+        <p><strong>Constable:</strong> ${s.constable || ''}</p>
+        <p><strong>Location:</strong> ${s.location || ''}</p>
+      </div>`;
+    })
+    .join('');
+
+  return `
+    <!DOCTYPE html>
+    <html>
+      <head>
+        <meta charset="UTF-8" />
+        <title>Crash Report Summary</title>
+        <style>
+          body { font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif; background:#f5f5f5; margin:0; padding:20px; }
+          .container { max-width:600px; margin:auto; background:#fff; padding:30px; border-radius:8px; box-shadow:0 2px 12px rgba(0,0,0,0.05); }
+          h1 { font-size:20px; margin-bottom:20px; }
+        </style>
+      </head>
+      <body>
+        <div class="container">
+          <h1>Crash Report Summary - ${incidentNumber}</h1>
+          ${parties}
+        </div>
+      </body>
+    </html>
+  `;
+}


### PR DESCRIPTION
## Summary
- implement crash report submission API with Resend email
- add manual final summary email API
- create simple admin dashboard for officers to manage crash reports

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853272a87e88324876d1a1a5321d70f