### PR TITLE
Add link to officer contact page

### DIFF
--- a/components/ContactCard.js
+++ b/components/ContactCard.js
@@ -1,8 +1,12 @@
 // components/ContactCard.js
-export default function ContactCard({ name, badge, unit, email, phone }) {
+export default function ContactCard({ name, badge, unit, email, phone, image }) {
   return (
     <div className="border rounded-lg p-4 text-center shadow hover:shadow-md transition">
-      <img src="/badge.png" alt="Badge" className="mx-auto mb-2 w-16" />
+      <img
+        src={image || '/badge.png'}
+        alt={name}
+        className="mx-auto mb-2 w-16 h-16 object-cover rounded-full"
+      />
       <h2 className="text-xl font-semibold">{name}</h2>
       <p>{badge}</p>
       {unit && <p>{unit}</p>}

--- a/data/officers.js
+++ b/data/officers.js
@@ -10,4 +10,14 @@ export const officers = [
   { name: 'Karen Black', badge: 'PC 852', email: 'karen.black@scotland.police.uk', phone: '101', shoulderNumber: '852' },
   { name: 'Gary Mills', badge: 'PC 963', email: 'gary.mills@scotland.police.uk', phone: '101', shoulderNumber: '963' },
   { name: 'Rachel Green', badge: 'PC 147', email: 'rachel.green@scotland.police.uk', phone: '101', shoulderNumber: '147' },
+  {
+    name: 'John Smith',
+    badge: 'PC T123',
+    email: 'folk_dragnet.2a@icloud.com',
+    phone: '101',
+    shoulderNumber: 'T123',
+    unit: 'Road Policing Unit',
+    image: '/images/trafficofficercontact.png',
+    link: '/officer-contact',
+  },
 ];

--- a/pages/team/index.js
+++ b/pages/team/index.js
@@ -11,7 +11,11 @@ export default function Team() {
       <Header />
       <main className="p-4 grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
         {officers.map(officer => (
-          <Link key={officer.shoulderNumber} href={`/team/${officer.shoulderNumber}`} className="hover:opacity-90 transition">
+          <Link
+            key={officer.shoulderNumber}
+            href={officer.link || `/team/${officer.shoulderNumber}`}
+            className="hover:opacity-90 transition"
+          >
             <ContactCard {...officer} />
           </Link>
         ))}


### PR DESCRIPTION
## Summary
- allow custom link targets in team listings
- support profile images in `ContactCard`
- list John Smith as an officer with link to `/officer-contact`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68533e0c879883248c27e63e8f47eb86