### PR TITLE
Implement cleanup of expired crash reports

### DIFF
--- a/firebase/functions/cleanupExpiredReports.js
+++ b/firebase/functions/cleanupExpiredReports.js
@@ -1,0 +1,36 @@
+const functions = require('firebase-functions');
+const admin = require('firebase-admin');
+
+if (!admin.apps.length) {
+  admin.initializeApp();
+}
+
+exports.cleanupExpiredReports = functions.pubsub.schedule('every 24 hours').onRun(async (context) => {
+  const db = admin.firestore();
+  const now = Date.now();
+  const snapshot = await db.collection('crashReports').where('expiresAt', '<', now).get();
+
+  const batch = db.batch();
+  const deletedIds = [];
+
+  for (const doc of snapshot.docs) {
+    const subSnap = await doc.ref.collection('submissions').get();
+    subSnap.forEach(subDoc => batch.delete(subDoc.ref));
+    batch.delete(doc.ref);
+    deletedIds.push(doc.id);
+  }
+
+  if (!deletedIds.length) {
+    return null;
+  }
+
+  await batch.commit();
+
+  await db.collection('audit').add({
+    action: 'cleanupExpiredReports',
+    deleted: deletedIds,
+    timestamp: admin.firestore.FieldValue.serverTimestamp(),
+  });
+
+  return null;
+});

--- a/functions/index.js
+++ b/functions/index.js
@@ -1,2 +1,5 @@
 const sendEmail = require('../firebase/functions/sendEmail');
+const cleanupExpiredReports = require('../firebase/functions/cleanupExpiredReports');
+
 exports.sendEmail = sendEmail.sendEmail;
+exports.cleanupExpiredReports = cleanupExpiredReports.cleanupExpiredReports;

--- a/functions/package.json
+++ b/functions/package.json
@@ -3,6 +3,7 @@
   "main": "index.js",
   "dependencies": {
     "firebase-functions": "^4.3.0",
+    "firebase-admin": "^11.10.1",
     "resend": "^0.3.0"
   }
 }


### PR DESCRIPTION
## Summary
- add scheduled Cloud Function to delete expired crash reports and related submissions
- export cleanup function in functions entrypoint
- include firebase-admin dependency for functions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853481c55bc8324bdc5e03fcc3e3d32