### PR TITLE
Add confirmation email with view-report link

### DIFF
--- a/components/RTCForm.js
+++ b/components/RTCForm.js
@@ -76,6 +76,8 @@ export default function RTCForm() {
             phone: formData.contactNumber,
             constable: formData.officer,
             location: formData.location,
+            incidentDate: formData.incidentDate,
+            policeRef: formData.policeRef,
             vehicle: {
               makeModel: formData.makeModel,
               reg: formData.vehicleReg,


### PR DESCRIPTION
## Summary
- include date and reference when emailing after report submission
- store these details with the submission
- add note and link to `/view-report` in email

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853483d0dac8324a945b79012211f05