### PR TITLE
Add officer profile pages

### DIFF
--- a/components/OfficerProfile.tsx
+++ b/components/OfficerProfile.tsx
@@ -1,0 +1,89 @@
+import Image from 'next/image';
+import { PhoneIcon, EnvelopeIcon, MapPinIcon, IdentificationIcon } from '@heroicons/react/24/outline';
+import type { FC } from 'react';
+
+export interface OfficerProfileProps {
+  name: string;
+  badgeNumber: string;
+  collarNumber: string;
+  unit: string;
+  email: string;
+  profileImage: string;
+}
+
+const OfficerProfile: FC<OfficerProfileProps> = ({
+  name,
+  badgeNumber,
+  collarNumber,
+  unit,
+  email,
+  profileImage,
+}) => {
+  return (
+    <div className="flex flex-col min-h-screen bg-white dark:bg-black text-black dark:text-white">
+      {/* Header with hero image */}
+      <div className="relative w-full h-56 sm:h-72 md:h-80">
+        <Image
+          src="/images/queensferrycrossing-background.jpg"
+          alt="Banner image"
+          fill
+          sizes="100vw"
+          className="object-cover"
+          priority
+        />
+        <div className="absolute top-4 right-4 w-24 sm:w-32">
+          <Image
+            src="/images/police-scotland-logo-2.png"
+            alt="Police Scotland logo"
+            width={128}
+            height={128}
+          />
+        </div>
+        <div className="absolute -bottom-16 left-1/2 transform -translate-x-1/2 w-32 h-32 sm:w-40 sm:h-40 rounded-full border-4 border-white shadow-lg overflow-hidden">
+          <Image
+            src={profileImage || '/images/trafficofficercontact.png'}
+            alt={name}
+            fill
+            sizes="160px"
+            className="object-cover"
+          />
+        </div>
+      </div>
+
+      {/* Main content */}
+      <main className="flex-1 mt-20 px-4 text-center">
+        <h1 className="text-2xl font-semibold">{name}</h1>
+        <p className="mt-1 font-medium">Badge: {badgeNumber}</p>
+        <p className="mt-1">Collar Number: {collarNumber}</p>
+        <p className="mt-1 italic">{unit}</p>
+
+        <div className="mt-4 flex justify-center space-x-6">
+          <a href={`tel:${badgeNumber}`} className="text-gray-600 dark:text-gray-300 hover:text-blue-600">
+            <PhoneIcon className="w-6 h-6" />
+          </a>
+          <a href={`mailto:${email}`} className="text-gray-600 dark:text-gray-300 hover:text-blue-600">
+            <EnvelopeIcon className="w-6 h-6" />
+          </a>
+          <a href="#location" className="text-gray-600 dark:text-gray-300 hover:text-blue-600">
+            <MapPinIcon className="w-6 h-6" />
+          </a>
+          <a href="#badge" className="text-gray-600 dark:text-gray-300 hover:text-blue-600">
+            <IdentificationIcon className="w-6 h-6" />
+          </a>
+        </div>
+
+        <div className="mt-6">
+          <a
+            href={`mailto:${email}`}
+            className="inline-block px-6 py-2 rounded-full bg-blue-600 text-white hover:bg-blue-700 transition"
+          >
+            Contact Officer
+          </a>
+        </div>
+      </main>
+    </div>
+  );
+};
+
+export default OfficerProfile;
+

--- a/data/officerProfiles.ts
+++ b/data/officerProfiles.ts
@@ -1,0 +1,22 @@
+import { OfficerProfileProps } from '@/components/OfficerProfile';
+
+export const officerProfiles: (OfficerProfileProps & { id: string })[] = [
+  {
+    id: 'john-smith',
+    name: 'PC John Smith',
+    badgeNumber: '1232342',
+    collarNumber: 'T123',
+    unit: 'Road Policing Unit',
+    email: 'folk_dragnet.2a@icloud.com',
+    profileImage: '/images/trafficofficercontact.png',
+  },
+  {
+    id: 'anna-smith',
+    name: 'PC Anna Smith',
+    badgeNumber: '654321',
+    collarNumber: 'R456',
+    unit: 'Community Policing',
+    email: 'anna.smith@scotland.police.uk',
+    profileImage: '/images/trafficofficercontact.png',
+  },
+];

--- a/pages/officers/[id].tsx
+++ b/pages/officers/[id].tsx
@@ -1,0 +1,14 @@
+import { useRouter } from 'next/router';
+import OfficerProfile from '@/components/OfficerProfile';
+import { officerProfiles } from '@/data/officerProfiles';
+
+export default function OfficerPage() {
+  const router = useRouter();
+  const { id } = router.query;
+
+  if (!id) return null;
+
+  const officer = officerProfiles.find((o) => o.id === id);
+  if (!officer) return <p className="p-4">Officer not found</p>;
+  return <OfficerProfile {...officer} />;
+}

--- a/pages/officers/index.tsx
+++ b/pages/officers/index.tsx
@@ -1,0 +1,19 @@
+import Link from 'next/link';
+import Header from '@/components/Header';
+import { officerProfiles } from '@/data/officerProfiles';
+
+export default function OfficersIndex() {
+  return (
+    <div className="min-h-screen bg-white dark:bg-black text-black dark:text-white">
+      <Header />
+      <main className="p-4 grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
+        {officerProfiles.map((officer) => (
+          <Link key={officer.id} href={`/officers/${officer.id}`} className="border rounded-lg p-4 hover:shadow">
+            <p className="font-semibold">{officer.name}</p>
+            <p className="text-sm text-gray-600">{officer.unit}</p>
+          </Link>
+        ))}
+      </main>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `OfficerProfile` reusable component with hero banner and contact icons
- create officers data for sample officers
- list officers on `/officers` page
- show individual officer page via `/officers/[id]`

## Testing
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_68534d1604cc83249ee260aab6ae20d2