### PR TITLE
Fix Firestore config and RTC form submission

### DIFF
--- a/components/RTCForm.js
+++ b/components/RTCForm.js
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useRouter } from 'next/router';
-import { collection, addDoc, serverTimestamp, Timestamp } from 'firebase/firestore';
+import { collection, addDoc, serverTimestamp } from 'firebase/firestore';
 import { db } from '@/firebase/client';
 
 export default function RTCForm() {
@@ -59,14 +59,9 @@ export default function RTCForm() {
     e.preventDefault();
     setSubmitting(true);
     try {
-      const now = Timestamp.now();
       const docRef = await addDoc(collection(db, 'rtc'), {
         ...formData,
         created: serverTimestamp(),
-        createdAt: now,
-        expiresAt: Timestamp.fromMillis(
-          now.toMillis() + 30 * 24 * 60 * 60 * 1000
-        ),
       });
       // Send confirmation email using API route, but don't block form submission
       fetch('/api/submit', {

--- a/firebase/client.js
+++ b/firebase/client.js
@@ -1,17 +1,27 @@
 // firebase/client.js
 import { initializeApp, getApp, getApps } from 'firebase/app';
-import { getFirestore } from 'firebase/firestore';
+import { getAnalytics } from 'firebase/analytics';
+import { getFirestore, setLogLevel } from 'firebase/firestore';
 
 const firebaseConfig = {
-  apiKey:            process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
-  authDomain:        process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
-  projectId:         process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
-  storageBucket:     process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET,
-  messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID,
-  appId:             process.env.NEXT_PUBLIC_FIREBASE_APP_ID,
+  apiKey: "AIzaSyCNBCnQYJAykquj_bVcXOdKfeU0So3Depc",
+  authDomain: "contact-cards-b9175.firebaseapp.com",
+  projectId: "contact-cards-b9175",
+  storageBucket: "contact-cards-b9175.appspot.com",
+  messagingSenderId: "1083444636856",
+  appId: "1:1083444636856:web:82a43f44cf921dc9eb184d",
+  measurementId: "G-EMC2XRVL0C",
 };
 
 // Initialize firebase only once, even if hot-reloaded
 const app = !getApps().length ? initializeApp(firebaseConfig) : getApp();
+
+// Enable verbose Firestore logs for easier debugging
+setLogLevel('debug');
+
+// Initialise analytics only in the browser
+if (typeof window !== 'undefined') {
+  getAnalytics(app);
+}
 
 export const db = getFirestore(app);


### PR DESCRIPTION
## Summary
- ensure Firebase initialization uses real project config
- init analytics only in browser and enable Firestore debug logs
- simplify RTC form submit payload and use shared db instance

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853e26b0f40832491182fcf0f5a856e