### PR TITLE
Add crash report lookup form

### DIFF
--- a/components/ReportLookupForm.js
+++ b/components/ReportLookupForm.js
@@ -1,0 +1,84 @@
+import { useState } from 'react';
+
+export default function ReportLookupForm() {
+  const [form, setForm] = useState({ policeRef: '', incidentDate: '', email: '' });
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+  const [report, setReport] = useState(null);
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setForm(prev => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setError('');
+    setReport(null);
+    setLoading(true);
+    try {
+      const res = await fetch('/api/report-lookup', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(form),
+      });
+      if (!res.ok) {
+        throw new Error('not found');
+      }
+      const data = await res.json();
+      setReport(data);
+    } catch (err) {
+      console.error(err);
+      setError('No matching report found, or your email address does not match our records.');
+    }
+    setLoading(false);
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4 text-base">
+      <div>
+        <label className="block font-medium">Police Ref Number</label>
+        <input
+          type="text"
+          name="policeRef"
+          value={form.policeRef}
+          onChange={handleChange}
+          pattern="\\d{4}"
+          required
+          className="mt-1 block w-full p-3 border rounded text-base"
+        />
+      </div>
+      <div>
+        <label className="block font-medium">Date of Incident</label>
+        <input
+          type="date"
+          name="incidentDate"
+          value={form.incidentDate}
+          onChange={handleChange}
+          required
+          className="mt-1 block w-full p-3 border rounded text-base"
+        />
+      </div>
+      <div>
+        <label className="block font-medium">Email Address</label>
+        <input
+          type="email"
+          name="email"
+          value={form.email}
+          onChange={handleChange}
+          required
+          className="mt-1 block w-full p-3 border rounded text-base"
+        />
+      </div>
+      {error && <p className="text-red-600">{error}</p>}
+      <button type="submit" disabled={loading} className="px-6 py-3 rounded-full bg-blue-600 text-white hover:bg-blue-700 transition text-base">
+        {loading ? 'Searching...' : 'Search Report'}
+      </button>
+      {report && (
+        <pre className="p-2 bg-gray-100 rounded overflow-x-auto text-sm mt-4">
+          {JSON.stringify(report, null, 2)}
+        </pre>
+      )}
+    </form>
+  );
+}

--- a/pages/api/report-lookup.js
+++ b/pages/api/report-lookup.js
@@ -1,0 +1,40 @@
+import { initializeApp, getApps } from 'firebase/app';
+import { getFirestore, doc, getDoc, collection, getDocs } from 'firebase/firestore';
+
+const firebaseConfig = {
+  apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
+  authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
+  projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
+};
+
+if (!getApps().length) initializeApp(firebaseConfig);
+const db = getFirestore();
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') return res.status(405).end();
+
+  const { policeRef, incidentDate, email } = req.body || {};
+  if (!policeRef || !incidentDate || !email) {
+    return res.status(400).json({ error: 'Missing parameters' });
+  }
+
+  try {
+    const id = `PS-${incidentDate.replace(/-/g, '')}-${policeRef}`;
+    const docRef = doc(db, 'rtc', id);
+    const snap = await getDoc(docRef);
+    if (!snap.exists()) {
+      return res.status(404).json({ error: 'not found' });
+    }
+    const data = snap.data();
+    const subsSnap = await getDocs(collection(db, 'rtc', id, 'submissions'));
+    const submissions = subsSnap.docs.map(d => ({ id: d.id, ...d.data() }));
+    const hasEmail = submissions.some(s => s.email && s.email.toLowerCase() === email.toLowerCase());
+    if (!hasEmail) {
+      return res.status(404).json({ error: 'not found' });
+    }
+    return res.status(200).json({ incident: { id, ...data }, submissions });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Server error' });
+  }
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -7,6 +7,7 @@ import { QrCodeIcon, ListBulletIcon, EnvelopeIcon } from '@heroicons/react/24/ou
 import Header from '@/components/Header'
 import Footer from '@/components/Footer'
 import ContactCard from '@/components/ContactCard'
+import ReportLookupForm from '@/components/ReportLookupForm'
 import { officers } from '@/data/officers'
 
 export default function Home() {
@@ -63,6 +64,17 @@ export default function Home() {
                   className="mx-auto"
                 />
               </div>
+            </div>
+          </section>
+
+          {/* FIND REPORT */}
+          <section className="bg-gray-50 py-12 px-4">
+            <div className="max-w-md mx-auto text-center">
+              <h2 className="text-2xl font-semibold mb-2">Find Your Crash Report</h2>
+              <p className="text-gray-700 mb-4">
+                Enter your details below to securely access your crash report. Reports are available for 30 days after submission.
+              </p>
+              <ReportLookupForm />
             </div>
           </section>
 


### PR DESCRIPTION
## Summary
- create `ReportLookupForm` component with email verification
- set RTC document IDs from date and reference
- add `report-lookup` API endpoint
- embed lookup form on the homepage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853f6387bd0832490c6a85798eb17f6