### PR TITLE
Add address lookup fields to crash report

### DIFF
--- a/components/RTCForm.js
+++ b/components/RTCForm.js
@@ -12,6 +12,9 @@ export default function RTCForm() {
     makeModel: '',
     driverName: '',
     ownerName: '',
+    postcode: '',
+    houseNumber: '',
+    address: '',
     insuranceCompany: '',
     policyNo: '',
     location: '',
@@ -24,6 +27,8 @@ export default function RTCForm() {
     contactNumber: '',
   });
   const [submitting, setSubmitting] = useState(false);
+  const [addresses, setAddresses] = useState([]);
+  const [addressLoading, setAddressLoading] = useState(false);
 
   const officers = [
     { value: 'T329 PC Wishart', label: 'T329 PC Wishart' },
@@ -53,6 +58,24 @@ export default function RTCForm() {
       },
       () => alert('Unable to retrieve your location')
     );
+  };
+
+  const lookupAddresses = async () => {
+    if (!formData.postcode) return;
+    setAddressLoading(true);
+    setAddresses([]);
+    try {
+      const res = await fetch(
+        `/api/address-lookup?postcode=${encodeURIComponent(formData.postcode)}&house=${encodeURIComponent(formData.houseNumber)}`
+      );
+      if (!res.ok) throw new Error('failed');
+      const data = await res.json();
+      setAddresses(data.addresses || []);
+    } catch (err) {
+      console.error(err);
+      alert('Address lookup failed');
+    }
+    setAddressLoading(false);
   };
 
   const handleSubmit = async (e) => {
@@ -124,6 +147,52 @@ export default function RTCForm() {
             className="mt-1 block w-full p-3 border rounded text-base"
           />
         </div>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4 items-end">
+        <div>
+          <label className="block font-medium">Postcode:</label>
+          <input
+            type="text"
+            name="postcode"
+            value={formData.postcode}
+            onChange={handleChange}
+            className="mt-1 block w-full p-3 border rounded text-base"
+          />
+        </div>
+        <div>
+          <label className="block font-medium">House No.</label>
+          <input
+            type="text"
+            name="houseNumber"
+            value={formData.houseNumber}
+            onChange={handleChange}
+            className="mt-1 block w-full p-3 border rounded text-base"
+          />
+        </div>
+      </div>
+
+      <div className="flex items-center space-x-2 mb-4">
+        <button
+          type="button"
+          onClick={lookupAddresses}
+          className="px-4 py-2 bg-gray-200 rounded"
+        >
+          {addressLoading ? 'Searching...' : 'Find Address'}
+        </button>
+        {addresses.length > 0 && (
+          <select
+            name="address"
+            value={formData.address}
+            onChange={handleChange}
+            className="p-3 border rounded text-base"
+          >
+            <option value="">Select address</option>
+            {addresses.map(addr => (
+              <option key={addr} value={addr}>{addr}</option>
+            ))}
+          </select>
+        )}
       </div>
 
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">

--- a/pages/api/address-lookup.js
+++ b/pages/api/address-lookup.js
@@ -1,0 +1,17 @@
+export default async function handler(req, res) {
+  const { postcode = '', house = '' } = req.query;
+  if (!postcode) return res.status(400).json({ error: 'Postcode required' });
+  try {
+    const url = `https://api.getAddress.io/find/${encodeURIComponent(postcode)}/${encodeURIComponent(house)}?api-key=${process.env.GETADDRESS_API_KEY}`;
+    const resp = await fetch(url);
+    if (!resp.ok) {
+      const text = await resp.text();
+      throw new Error(text);
+    }
+    const data = await resp.json();
+    res.status(200).json({ addresses: data.addresses || [] });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to fetch addresses' });
+  }
+}

--- a/pages/report/[id].js
+++ b/pages/report/[id].js
@@ -46,6 +46,9 @@ export default function MergedReport() {
               <div key={s.id} className="border p-4 rounded">
                 <h2 className="font-semibold mb-2">Party {idx + 1}</h2>
                 <p><strong>Name:</strong> {s.fullName}</p>
+                {s.address && (
+                  <p><strong>Address:</strong> {s.address}</p>
+                )}
                 {s.vehicle && (
                   <p><strong>Vehicle:</strong> {s.vehicle.make} {s.vehicle.model} ({s.vehicle.colour}) - {s.vehicle.reg}</p>
                 )}

--- a/pages/rtc/[id].js
+++ b/pages/rtc/[id].js
@@ -62,6 +62,12 @@ export default function RTCView() {
             <span className="font-medium">Driver:</span>{' '}
             {value.driverName}
           </p>
+          {value.address && (
+            <p>
+              <span className="font-medium">Address:</span>{' '}
+              {value.address}
+            </p>
+          )}
           {value.ownerName && (
             <p>
               <span className="font-medium">Owner:</span>{' '}


### PR DESCRIPTION
## Summary
- allow postcode and house number collection on crash report form
- look up addresses via new `/api/address-lookup` endpoint
- show selected address when viewing a report

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685466139e408324bf67be35aa3fcef6