### PR TITLE
Add postcode lookup demo

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
+    "server": "node server.js",
     "test": "echo \"No tests\" && exit 0"
   },
   "dependencies": {
@@ -17,7 +18,9 @@
     "react-dom": "18.2.0",
     "react-firebase-hooks": "^5.1.1",
     "react-qr-code": "^2.0.15",
-    "resend": "^4.6.0"
+    "resend": "^4.6.0",
+    "express": "^4.19.2",
+    "node-fetch": "^3.3.2"
   },
   "devDependencies": {
     "@types/node": "^24.0.3",

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>UK Postcode Lookup</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <h1>UK Postcode Lookup</h1>
+  <form id="lookup-form">
+    <label for="postcode">Postcode:</label>
+    <input id="postcode" type="text" />
+    <button type="button" id="lookup-btn">Find address</button>
+  </form>
+
+  <div id="address-container" style="display: none;">
+    <label for="address-select">Select address:</label>
+    <select id="address-select"></select>
+  </div>
+
+  <div id="address-fields" style="display: none;">
+    <input id="line1" readonly placeholder="Address line 1" />
+    <input id="line2" readonly placeholder="Address line 2" />
+    <input id="town" readonly placeholder="Town" />
+    <input id="county" readonly placeholder="County" />
+  </div>
+
+  <script src="main.js"></script>
+</body>
+</html>

--- a/public/main.js
+++ b/public/main.js
@@ -1,0 +1,56 @@
+const postcodeInput = document.getElementById('postcode');
+const lookupBtn = document.getElementById('lookup-btn');
+const addressContainer = document.getElementById('address-container');
+const addressSelect = document.getElementById('address-select');
+const addressFields = document.getElementById('address-fields');
+const line1 = document.getElementById('line1');
+const line2 = document.getElementById('line2');
+const town = document.getElementById('town');
+const county = document.getElementById('county');
+
+const ukPostcodeRegex = /^[A-Z]{1,2}\d{1,2}[A-Z]? \d[A-Z]{2}$/i;
+
+async function lookup() {
+  const postcode = postcodeInput.value.trim();
+  if (!ukPostcodeRegex.test(postcode)) {
+    alert('Please enter a valid UK postcode');
+    return;
+  }
+
+  lookupBtn.disabled = true;
+  lookupBtn.textContent = 'Looking up...';
+  try {
+    const res = await fetch(`/api/uk-addresses?postcode=${encodeURIComponent(postcode)}`);
+    if (!res.ok) {
+      throw new Error('lookup failed');
+    }
+    const data = await res.json();
+    addressSelect.innerHTML = '';
+    data.addresses.forEach(addr => {
+      const option = document.createElement('option');
+      option.value = addr;
+      option.textContent = addr;
+      addressSelect.appendChild(option);
+    });
+    addressContainer.style.display = 'block';
+  } catch (err) {
+    console.error(err);
+    alert('Failed to lookup postcode');
+  }
+  lookupBtn.disabled = false;
+  lookupBtn.textContent = 'Find address';
+}
+
+lookupBtn.addEventListener('click', lookup);
+postcodeInput.addEventListener('blur', () => {
+  if (postcodeInput.value.trim()) lookup();
+});
+
+addressSelect.addEventListener('change', () => {
+  const parts = addressSelect.value.split(',').map(p => p.trim());
+  line1.value = parts[0] || '';
+  line2.value = parts[1] || '';
+  town.value = parts[parts.length - 2] || '';
+  county.value = parts[parts.length - 1] || '';
+  addressFields.style.display = 'block';
+});

--- a/public/style.css
+++ b/public/style.css
@@ -1,0 +1,2 @@
+body { font-family: Arial, sans-serif; padding: 2rem; }
+#address-container, #address-fields { margin-top: 1rem; }

--- a/server.js
+++ b/server.js
@@ -1,0 +1,38 @@
+const express = require('express');
+const fetch = require('node-fetch');
+const path = require('path');
+
+const app = express();
+const PORT = process.env.PORT || 3000;
+
+// Serve static files (for index.html and main.js)
+app.use(express.static(path.join(__dirname, 'public')));
+
+// GET /api/uk-addresses?postcode=...
+app.get('/api/uk-addresses', async (req, res) => {
+  const postcode = req.query.postcode ? req.query.postcode.toString().trim() : '';
+  if (!postcode) {
+    return res.status(400).json({ error: 'Postcode query parameter required' });
+  }
+
+  try {
+    const url = `https://api.postcodes.io/postcodes/${encodeURIComponent(postcode)}/autocomplete`;
+    const response = await fetch(url);
+    if (!response.ok) {
+      return res.status(502).json({ error: 'Failed to fetch postcode data' });
+    }
+    const data = await response.json();
+    const results = data && Array.isArray(data.result) ? data.result : [];
+    if (results.length === 0) {
+      return res.status(404).json({ error: 'No addresses found' });
+    }
+    res.json({ addresses: results });
+  } catch (err) {
+    console.error(err);
+    res.status(502).json({ error: 'Failed to fetch postcode data' });
+  }
+});
+
+app.listen(PORT, () => {
+  console.log(`Server listening on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- add Express server proxying Postcodes.io
- add vanilla JS demo page for postcode lookup and autofill
- add minimal CSS
- install express and node-fetch

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685469451ab4832493156bd4dfc8472b