### PR TITLE
Fix police reference input validation

### DIFF
--- a/components/RTCForm.js
+++ b/components/RTCForm.js
@@ -144,6 +144,8 @@ export default function RTCForm() {
             value={formData.policeRef}
             onChange={handleChange}
             placeholder="If known"
+            pattern="\\d{4}"
+            maxLength={4}
             className="mt-1 block w-full p-3 border rounded text-base"
           />
         </div>


### PR DESCRIPTION
## Summary
- restrict `policeRef` field to 4 digits in RTC form

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685473e431cc8324a432190d4ad5332e