### PR TITLE
Fix duplicate attributes in RTCForm

### DIFF
--- a/components/RTCForm.js
+++ b/components/RTCForm.js
@@ -148,8 +148,6 @@ export default function RTCForm() {
             pattern="\d{4}"
             maxLength={4}
             placeholder="If known"
-            pattern="\\d{4}"
-            maxLength={4}
             className="mt-1 block w-full p-3 border rounded text-base"
           />
         </div>


### PR DESCRIPTION
## Summary
- remove redundant `pattern` and `maxLength` attributes from the `policeRef` input field

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685476cfbb6483248b44d4f0f5b6fa1d