### PR TITLE
Remove dark mode toggle

### DIFF
--- a/components/Header.js
+++ b/components/Header.js
@@ -1,24 +1,12 @@
 // components/Header.js
 import Link from 'next/link';
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 
 export default function Header() {
-  const [dark, setDark] = useState(false);
-
   useEffect(() => {
-    const stored = localStorage.getItem('dark');
-    if (stored === 'true') {
-      document.documentElement.classList.add('dark');
-      setDark(true);
-    }
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    document.documentElement.classList.toggle('dark', prefersDark);
   }, []);
-
-  const toggle = () => {
-    const next = !dark;
-    setDark(next);
-    localStorage.setItem('dark', next);
-    document.documentElement.classList.toggle('dark', next);
-  };
 
   return (
     <header className="sticky top-0 z-20 flex items-center justify-between bg-black text-white px-6 py-3">
@@ -31,9 +19,6 @@ export default function Header() {
           Police Scotland
         </Link>
       </nav>
-      <button aria-label="Toggle Dark Mode" onClick={toggle} className="ml-4">
-        {dark ? '☀️' : '🌙'}
-      </button>
     </header>
   );
 }


### PR DESCRIPTION
## Summary
- automatically apply user's system theme on load
- drop the dark mode toggle button from the header

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685481d01b748324a229c78d0c4c4df6