### PR TITLE
Update README with npm test docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,15 @@ npm install
 npm run dev
 ```
 
+## Testing
+
+Run the Jest test suite. **Ensure you run `npm install` first** so all dev dependencies are available in CI or your local environment:
+
+```bash
+npm install
+npm test
+```
+
 ## Firebase Deployment
 
 Copy `.env.example` to `.env.local` and fill in your Firebase, Resend and base URL settings. The relevant environment variables are:


### PR DESCRIPTION
## Summary
- add Testing section to README to mention running `npm install` before `npm test`

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685494a0410c8324928ae214c15979df