### PR TITLE
Add statement page link to header menu

### DIFF
--- a/components/Header.js
+++ b/components/Header.js
@@ -33,6 +33,9 @@ export default function Header() {
         <Link href="/rtc/new" className="block hover:underline" onClick={() => setMenuOpen(false)}>
           Start Report
         </Link>
+        <Link href="/statements/new" className="block hover:underline" onClick={() => setMenuOpen(false)}>
+          Statement
+        </Link>
         <Link href="/officers" className="block hover:underline" onClick={() => setMenuOpen(false)}>
           Officers
         </Link>


### PR DESCRIPTION
## Summary
- link to statement form from the header menu

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685585fc0ca88324bb7663186307da61