### PR TITLE
Update Firestore rules

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -2,6 +2,9 @@
   "functions": {
     "source": "functions"
   },
+  "firestore": {
+    "rules": "firestore.rules"
+  },
   "hosting": {
     "public": "public",
     "ignore": [

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,8 +1,9 @@
 rules_version = '2';
 service cloud.firestore {
-  match /databases/{database}/documents {
+  match /databases/{db}/documents {
     match /rtc/{id} {
-      allow read, write: if true;
+      allow read: if request.auth != null;
+      allow write: if request.auth != null && request.auth.token.admin == true;
     }
   }
 }


### PR DESCRIPTION
## Summary
- restrict Firestore read access to authenticated users
- allow writes only to authenticated admins
- add Firestore rules configuration to `firebase.json`

## Testing
- `npm test`
- `firebase deploy --only firestore:rules` *(fails: Failed to authenticate, have you run firebase login?)*

------
https://chatgpt.com/codex/tasks/task_e_68584fa29eb88324b9f8d8e23308b8aa