### PR TITLE
Add server API for OpenAI statement generation

### DIFF
--- a/components/StatementForm.js
+++ b/components/StatementForm.js
@@ -54,22 +54,15 @@ export default function StatementForm() {
       text = template({ ...formData, otherParties, witnesses });
     } else {
       try {
-        const res = await fetch('https://api.openai.com/v1/chat/completions', {
+        const res = await fetch('/api/generate-statement', {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
-            Authorization: `Bearer ${process.env.NEXT_PUBLIC_OPENAI_API_KEY}`,
           },
-          body: JSON.stringify({
-            model: 'gpt-3.5-turbo',
-            messages: [
-              { role: 'system', content: 'You are a police administrative assistant...' },
-              { role: 'user', content: JSON.stringify({ ...formData, otherParties, witnesses }) },
-            ],
-          }),
+          body: JSON.stringify({ ...formData, otherParties, witnesses }),
         });
         const data = await res.json();
-        text = data.choices?.[0]?.message?.content || '';
+        text = data.text || '';
       } catch (err) {
         console.error(err);
         text = 'Failed to generate statement';

--- a/pages/api/generate-statement.js
+++ b/pages/api/generate-statement.js
@@ -1,0 +1,23 @@
+import OpenAI from 'openai';
+
+const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') return res.status(405).end();
+
+  try {
+    const body = req.body || {};
+    const completion = await openai.chat.completions.create({
+      model: 'gpt-3.5-turbo',
+      messages: [
+        { role: 'system', content: 'You are a police administrative assistant...' },
+        { role: 'user', content: JSON.stringify(body) },
+      ],
+    });
+    const text = completion.choices?.[0]?.message?.content || '';
+    res.status(200).json({ text });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to generate statement' });
+  }
+}


### PR DESCRIPTION
## Summary
- add `/api/generate-statement` to call OpenAI using server-side key
- update `StatementForm` to use the new API route

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685850bb26108324945ced7394c0fc00