### PR TITLE
Add Firebase config validation

### DIFF
--- a/__tests__/firebase.test.js
+++ b/__tests__/firebase.test.js
@@ -1,0 +1,54 @@
+
+
+jest.mock('firebase/app', () => ({
+  initializeApp: jest.fn(),
+  getApp: jest.fn(),
+  getApps: jest.fn(() => []),
+}));
+
+jest.mock('firebase/analytics', () => ({
+  getAnalytics: jest.fn(),
+}));
+
+jest.mock('firebase/firestore', () => {
+  const mocks = {
+    getFirestore: jest.fn(() => ({})),
+    setLogLevel: jest.fn(),
+  };
+  return { __esModule: true, ...mocks };
+});
+
+const REQUIRED = [
+  'NEXT_PUBLIC_FIREBASE_API_KEY',
+  'NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN',
+  'NEXT_PUBLIC_FIREBASE_PROJECT_ID',
+  'NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET',
+  'NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID',
+  'NEXT_PUBLIC_FIREBASE_APP_ID',
+  'NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID',
+];
+
+const originalEnv = { ...process.env };
+
+beforeEach(() => {
+  jest.resetModules();
+  process.env = { ...originalEnv };
+  REQUIRED.forEach(v => (process.env[v] = 'test'));
+});
+
+afterEach(() => {
+  process.env = originalEnv;
+});
+
+describe('firebase config validation', () => {
+  it('throws error when env vars missing', () => {
+    delete process.env.NEXT_PUBLIC_FIREBASE_API_KEY;
+    expect(() => require('../firebase/client')).toThrow(
+      /NEXT_PUBLIC_FIREBASE_API_KEY/
+    );
+  });
+
+  it('does not throw when all vars present', () => {
+    expect(() => require('../firebase/client')).not.toThrow();
+  });
+});

--- a/firebase/client.js
+++ b/firebase/client.js
@@ -2,6 +2,10 @@
 import { initializeApp, getApp, getApps } from 'firebase/app';
 import { getAnalytics } from 'firebase/analytics';
 import { getFirestore, setLogLevel } from 'firebase/firestore';
+import validateConfig from './validateConfig';
+
+// Ensure required environment variables are present
+validateConfig();
 
 const firebaseConfig = {
   apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,

--- a/firebase/validateConfig.js
+++ b/firebase/validateConfig.js
@@ -1,0 +1,16 @@
+export const REQUIRED_VARS = [
+  'NEXT_PUBLIC_FIREBASE_API_KEY',
+  'NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN',
+  'NEXT_PUBLIC_FIREBASE_PROJECT_ID',
+  'NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET',
+  'NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID',
+  'NEXT_PUBLIC_FIREBASE_APP_ID',
+  'NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID',
+];
+
+export default function validateConfig(env = process.env) {
+  const missing = REQUIRED_VARS.filter(name => !env[name]);
+  if (missing.length) {
+    throw new Error(`Missing Firebase config variables: ${missing.join(', ')}`);
+  }
+}


### PR DESCRIPTION
## Summary
- add validation helper to check required Firebase env vars
- ensure client initialization runs validation
- test missing Firebase config throws an error

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685864e3f1a083249232495480515910