### PR TITLE
Allow locationNotes docs in Firestore rules

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -2,6 +2,7 @@ rules_version = '2';
 service cloud.firestore {
   match /databases/{db}/documents {
     match /rtc/{id} {
+      // allow storing optional locationNotes on RTC documents
       allow read: if request.auth != null;
       allow write: if request.auth != null && request.auth.token.admin == true;
     }


### PR DESCRIPTION
## Summary
- update Firestore rules comment to clarify that new `locationNotes` field is allowed

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68586a8c9c80832494abe880c568bbb3