### PR TITLE
Move Firebase validation into handlers

### DIFF
--- a/__tests__/api.test.js
+++ b/__tests__/api.test.js
@@ -47,9 +47,12 @@ describe('firebase config validation for API routes', () => {
     '../pages/api/final-summary.js',
   ];
 
-  test.each(modules)('%s throws when env vars missing', mod => {
+  test.each(modules)('%s throws when env vars missing', async mod => {
     delete process.env.NEXT_PUBLIC_FIREBASE_API_KEY;
-    expect(() => require(mod)).toThrow(/NEXT_PUBLIC_FIREBASE_API_KEY/);
+    const handler = require(mod).default;
+    await expect(handler({ method: 'POST', body: {}, query: {} }, {})).rejects.toThrow(
+      /NEXT_PUBLIC_FIREBASE_API_KEY/
+    );
   });
 });
 

--- a/__tests__/firebase.test.js
+++ b/__tests__/firebase.test.js
@@ -43,12 +43,12 @@ afterEach(() => {
 describe('firebase config validation', () => {
   it('throws error when env vars missing', () => {
     delete process.env.NEXT_PUBLIC_FIREBASE_API_KEY;
-    expect(() => require('../firebase/client')).toThrow(
-      /NEXT_PUBLIC_FIREBASE_API_KEY/
-    );
+    const { default: validateConfig } = require('../firebase/validateConfig');
+    expect(() => validateConfig()).toThrow(/NEXT_PUBLIC_FIREBASE_API_KEY/);
   });
 
   it('does not throw when all vars present', () => {
-    expect(() => require('../firebase/client')).not.toThrow();
+    const { default: validateConfig } = require('../firebase/validateConfig');
+    expect(() => validateConfig()).not.toThrow();
   });
 });

--- a/firebase/client.js
+++ b/firebase/client.js
@@ -2,10 +2,6 @@
 import { initializeApp, getApp, getApps } from 'firebase/app';
 import { getAnalytics } from 'firebase/analytics';
 import { getFirestore, setLogLevel } from 'firebase/firestore';
-import validateConfig from './validateConfig';
-
-// Ensure required environment variables are present
-validateConfig();
 
 const firebaseConfig = {
   apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,

--- a/pages/api/final-summary.js
+++ b/pages/api/final-summary.js
@@ -3,9 +3,6 @@ import { initializeApp, getApps } from 'firebase/app';
 import { getFirestore, collection, getDocs } from 'firebase/firestore';
 import validateConfig from '../../firebase/validateConfig';
 
-// Validate Firebase configuration before using it
-validateConfig();
-
 const resend = new Resend(process.env.RESEND_API_KEY);
 
 const firebaseConfig = {
@@ -18,10 +15,11 @@ const firebaseConfig = {
   measurementId: process.env.NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID,
 };
 
-if (!getApps().length) initializeApp(firebaseConfig);
-const db = getFirestore();
 
 export default async function handler(req, res) {
+  validateConfig();
+  if (!getApps().length) initializeApp(firebaseConfig);
+  const db = getFirestore();
   if (req.method !== 'POST') return res.status(405).end();
 
   const { id } = req.query; // incident number

--- a/pages/api/report-lookup.js
+++ b/pages/api/report-lookup.js
@@ -2,9 +2,6 @@ import { initializeApp, getApps } from 'firebase/app';
 import { getFirestore, doc, getDoc, collection, getDocs } from 'firebase/firestore';
 import validateConfig from '../../firebase/validateConfig';
 
-// Validate Firebase configuration before using it
-validateConfig();
-
 const firebaseConfig = {
   apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
   authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
@@ -15,10 +12,11 @@ const firebaseConfig = {
   measurementId: process.env.NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID,
 };
 
-if (!getApps().length) initializeApp(firebaseConfig);
-const db = getFirestore();
 
 export default async function handler(req, res) {
+  validateConfig();
+  if (!getApps().length) initializeApp(firebaseConfig);
+  const db = getFirestore();
   if (req.method !== 'POST') return res.status(405).end();
 
   const { policeRef, incidentDate, email } = req.body || {};

--- a/pages/api/submit.js
+++ b/pages/api/submit.js
@@ -3,9 +3,6 @@ import { initializeApp, getApps } from 'firebase/app';
 import { getFirestore, doc, setDoc } from 'firebase/firestore';
 import validateConfig from '../../firebase/validateConfig';
 
-// Validate Firebase configuration before using it
-validateConfig();
-
 const resend = new Resend(process.env.RESEND_API_KEY);
 
 const firebaseConfig = {
@@ -18,10 +15,11 @@ const firebaseConfig = {
   measurementId: process.env.NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID,
 };
 
-if (!getApps().length) initializeApp(firebaseConfig);
-const db = getFirestore();
 
 export default async function handler(req, res) {
+  validateConfig();
+  if (!getApps().length) initializeApp(firebaseConfig);
+  const db = getFirestore();
   if (req.method !== 'POST') return res.status(405).end();
 
   const {


### PR DESCRIPTION
## Summary
- stop validating Firebase config when importing `firebase/client`
- perform validation and initialization at runtime inside API handlers
- update tests for new validation flow

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685873c7b59883248815677b93b9cabf