### PR TITLE
Fix Firestore permissions for rtc

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -3,8 +3,8 @@ service cloud.firestore {
   match /databases/{db}/documents {
     match /rtc/{id} {
       // allow storing optional locationNotes on RTC documents
-      allow read: if request.auth != null;
-      allow write: if request.auth != null && request.auth.token.admin == true;
+      // Public read/write access so users can submit and view RTC reports
+      allow read, write: if true;
     }
   }
 }


### PR DESCRIPTION
## Summary
- grant public read/write access to `rtc` documents so collision reports work without auth

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6867c15e83008324aeb9422f06d6b03b