### PR TITLE
Add phone field to officer profiles

### DIFF
--- a/components/OfficerProfile.tsx
+++ b/components/OfficerProfile.tsx
@@ -8,6 +8,7 @@ export interface OfficerProfileProps {
   collarNumber: string;
   unit: string;
   email: string;
+  phone?: string;
   profileImage: string;
 }
 
@@ -17,6 +18,7 @@ const OfficerProfile: FC<OfficerProfileProps> = ({
   collarNumber,
   unit,
   email,
+  phone,
   profileImage,
 }) => {
   return (
@@ -58,9 +60,11 @@ const OfficerProfile: FC<OfficerProfileProps> = ({
         <p className="mt-1 italic">{unit}</p>
 
         <div className="mt-4 flex justify-center space-x-6">
-          <a href={`tel:${badgeNumber}`} className="text-gray-600 dark:text-gray-300 hover:text-blue-600">
-            <PhoneIcon className="w-6 h-6" />
-          </a>
+          {phone && (
+            <a href={`tel:${phone}`} className="text-gray-600 dark:text-gray-300 hover:text-blue-600">
+              <PhoneIcon className="w-6 h-6" />
+            </a>
+          )}
           <a href={`mailto:${email}`} className="text-gray-600 dark:text-gray-300 hover:text-blue-600">
             <EnvelopeIcon className="w-6 h-6" />
           </a>

--- a/data/officerProfiles.ts
+++ b/data/officerProfiles.ts
@@ -8,6 +8,7 @@ export const officerProfiles: (OfficerProfileProps & { id: string })[] = [
     collarNumber: 'T123',
     unit: 'Road Policing Unit',
     email: 'folk_dragnet.2a@icloud.com',
+    phone: '101',
     profileImage: '/images/trafficofficercontact.png',
   },
   {
@@ -17,6 +18,7 @@ export const officerProfiles: (OfficerProfileProps & { id: string })[] = [
     collarNumber: 'T345',
     unit: 'Road Policing Unit',
     email: 'jane.doe@scotland.police.uk',
+    phone: '2345432',
     profileImage: '/images/trafficofficercontact.png',
   },
 ];


### PR DESCRIPTION
## Summary
- extend `OfficerProfileProps` with optional `phone`
- show phone link in `OfficerProfile` when provided
- include phone numbers in `data/officerProfiles`

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6867c16a0aa48324a3d6855056fbe8d0