### PR TITLE
Wrap Firestore debug logs with NODE_ENV check

### DIFF
--- a/__tests__/firebase.test.js
+++ b/__tests__/firebase.test.js
@@ -52,3 +52,19 @@ describe('firebase config validation', () => {
     expect(() => validateConfig()).not.toThrow();
   });
 });
+
+describe('firestore log level', () => {
+  it('enables debug logging when not in production', () => {
+    process.env.NODE_ENV = 'development';
+    require('../firebase/client');
+    const { setLogLevel } = require('firebase/firestore');
+    expect(setLogLevel).toHaveBeenCalledWith('debug');
+  });
+
+  it('does not enable debug logging in production', () => {
+    process.env.NODE_ENV = 'production';
+    require('../firebase/client');
+    const { setLogLevel } = require('firebase/firestore');
+    expect(setLogLevel).not.toHaveBeenCalled();
+  });
+});

--- a/firebase/client.js
+++ b/firebase/client.js
@@ -16,8 +16,10 @@ const firebaseConfig = {
 // Initialize firebase only once, even if hot-reloaded
 const app = !getApps().length ? initializeApp(firebaseConfig) : getApp();
 
-// Enable verbose Firestore logs for easier debugging
-setLogLevel('debug');
+// Enable verbose Firestore logs for easier debugging in non-production envs
+if (process.env.NODE_ENV !== 'production') {
+  setLogLevel('debug');
+}
 
 // Initialise analytics only in the browser
 if (typeof window !== 'undefined') {


### PR DESCRIPTION
## Summary
- avoid verbose Firestore logs in production
- test log level behaviour based on environment

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6867c175b19c83249e85ee35b2984e53