### PR TITLE
Fix icons in officer profile

### DIFF
--- a/components/OfficerProfile.tsx
+++ b/components/OfficerProfile.tsx
@@ -1,6 +1,7 @@
 import Image from 'next/image';
 import { PhoneIcon, EnvelopeIcon, MapPinIcon, IdentificationIcon } from '@heroicons/react/24/outline';
 import type { FC } from 'react';
+import { generateVCard } from '@/utils/vcard';
 
 export interface OfficerProfileProps {
   name: string;
@@ -68,10 +69,19 @@ const OfficerProfile: FC<OfficerProfileProps> = ({
           <a href={`mailto:${email}`} className="text-gray-600 dark:text-gray-300 hover:text-blue-600">
             <EnvelopeIcon className="w-6 h-6" />
           </a>
-          <a href="#location" className="text-gray-600 dark:text-gray-300 hover:text-blue-600">
+          <a
+            href="https://maps.app.goo.gl/QjDwBoPHeP6so7Ko8?g_st=ipc"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-gray-600 dark:text-gray-300 hover:text-blue-600"
+          >
             <MapPinIcon className="w-6 h-6" />
           </a>
-          <a href="#badge" className="text-gray-600 dark:text-gray-300 hover:text-blue-600">
+          <a
+            href={`data:text/vcard;charset=utf-8,${encodeURIComponent(generateVCard({ name, email, phone, unit }))}`}
+            download={`${name.replace(/\s+/g, '_')}.vcf`}
+            className="text-gray-600 dark:text-gray-300 hover:text-blue-600"
+          >
             <IdentificationIcon className="w-6 h-6" />
           </a>
         </div>

--- a/utils/vcard.js
+++ b/utils/vcard.js
@@ -1,11 +1,12 @@
 // utils/vcard.js
-export function generateVCard({ name, email, phone }) {
+export function generateVCard({ name, email, phone, unit }) {
   const lines = [
     'BEGIN:VCARD',
     'VERSION:3.0',
     `FN:${name}`,
+    `ORG:Police Scotland${unit ? `, ${unit}` : ''}`,
     `EMAIL:${email}`,
-    phone ? `TEL:${phone}` : '',
+    phone ? `TEL;TYPE=WORK,VOICE:${phone}` : '',
     'END:VCARD',
   ];
   return lines.filter(Boolean).join('\n');


### PR DESCRIPTION
## Summary
- generate vCards with org and phone metadata
- link officer location icon to Google Maps
- enable vCard download via identification icon

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6867c9d67d208324a633be448f6ec4af