### PR TITLE
Add redirect for RTC form

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,11 @@
+module.exports = {
+  async redirects() {
+    return [
+      {
+        source: '/api/rtc/new',
+        destination: '/rtc/new',
+        permanent: true,
+      },
+    ];
+  },
+};


### PR DESCRIPTION
## Summary
- add Next.js redirect from `/api/rtc/new` to `/rtc/new` to ensure Start Report goes to the form

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686852457d888324883afe0f3d22adfa