### PR TITLE
Add Firestore collection index pages

### DIFF
--- a/pages/report/index.tsx
+++ b/pages/report/index.tsx
@@ -1,0 +1,28 @@
+import Link from 'next/link';
+import Header from '@/components/Header';
+import { collection } from 'firebase/firestore';
+import { useCollection } from 'react-firebase-hooks/firestore';
+import { db } from '@/firebase/client';
+
+export default function ReportIndex() {
+  const [snapshot] = useCollection(collection(db, 'rtc'));
+
+  return (
+    <div className="min-h-screen bg-white dark:bg-black text-black dark:text-white">
+      <Header />
+      <main className="p-4 max-w-3xl mx-auto">
+        <h1 className="text-2xl mb-4">Crash Reports</h1>
+        {!snapshot && <p>Loading…</p>}
+        {snapshot && (
+          <ul className="space-y-2">
+            {snapshot.docs.map(doc => (
+              <li key={doc.id} className="border p-2 rounded">
+                <Link href={`/report/${doc.id}`}>{doc.id}</Link>
+              </li>
+            ))}
+          </ul>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/pages/rtc/index.tsx
+++ b/pages/rtc/index.tsx
@@ -1,0 +1,28 @@
+import Link from 'next/link';
+import Header from '@/components/Header';
+import { collection } from 'firebase/firestore';
+import { useCollection } from 'react-firebase-hooks/firestore';
+import { db } from '@/firebase/client';
+
+export default function RTCList() {
+  const [snapshot] = useCollection(collection(db, 'rtc'));
+
+  return (
+    <div className="min-h-screen bg-white dark:bg-black text-black dark:text-white">
+      <Header />
+      <main className="p-4 max-w-3xl mx-auto">
+        <h1 className="text-2xl mb-4">RTC Reports</h1>
+        {!snapshot && <p>Loading…</p>}
+        {snapshot && (
+          <ul className="space-y-2">
+            {snapshot.docs.map(doc => (
+              <li key={doc.id} className="border p-2 rounded">
+                <Link href={`/rtc/${doc.id}`}>{doc.id}</Link>
+              </li>
+            ))}
+          </ul>
+        )}
+      </main>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `/rtc` list page to browse reports
- add `/report` list page as an index of crash reports

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6869a9d4f3a88324bdc9e08c1898db38