### PR TITLE
Add Firebase auth guard and secure Firestore rules

### DIFF
--- a/components/AuthCheck.tsx
+++ b/components/AuthCheck.tsx
@@ -1,0 +1,34 @@
+import { ReactNode } from 'react';
+import { getAuth, GoogleAuthProvider, signInWithPopup } from 'firebase/auth';
+import { useAuthState } from 'react-firebase-hooks/auth';
+
+export default function AuthCheck({ children }: { children: ReactNode }) {
+  const auth = getAuth();
+  const [user, loading] = useAuthState(auth);
+
+  const signIn = async () => {
+    const provider = new GoogleAuthProvider();
+    try {
+      await signInWithPopup(auth, provider);
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  if (loading) return <p className="p-4">Loading…</p>;
+  if (!user) {
+    return (
+      <div className="p-4 space-y-4">
+        <p>You must sign in to access this page.</p>
+        <button
+          onClick={signIn}
+          className="px-4 py-2 bg-blue-600 text-white rounded"
+        >
+          Sign in with Google
+        </button>
+      </div>
+    );
+  }
+
+  return <>{children}</>;
+}

--- a/firestore.rules
+++ b/firestore.rules
@@ -2,9 +2,17 @@ rules_version = '2';
 service cloud.firestore {
   match /databases/{db}/documents {
     match /rtc/{id} {
-      // allow storing optional locationNotes on RTC documents
       // Public read/write access so users can submit and view RTC reports
       allow read, write: if true;
+      match /submissions/{subId} {
+        // Individual party submissions remain publicly writable
+        allow read, write: if true;
+      }
+    }
+
+    // Admin-only data
+    match /admin/{document=**} {
+      allow read, write: if request.auth != null;
     }
   }
 }

--- a/pages/admin/index.tsx
+++ b/pages/admin/index.tsx
@@ -4,6 +4,7 @@ import { collection, doc, updateDoc } from 'firebase/firestore';
 import { useCollection, useCollectionData } from 'react-firebase-hooks/firestore';
 import { db } from '@/firebase/client';
 import Header from '@/components/Header';
+import AuthCheck from '@/components/AuthCheck';
 
 function IncidentRow({ id }) {
   const submissionsRef = collection(db, 'rtc', id, 'submissions');
@@ -86,14 +87,16 @@ export default function AdminPage() {
     return <p className="p-4">Loading…</p>;
   }
   return (
-    <div className="min-h-screen bg-white dark:bg-black text-black dark:text-white">
-      <Header />
-      <main className="p-4 max-w-3xl mx-auto">
-        <h1 className="text-2xl mb-4">RTC Admin</h1>
-        {incidentsSnapshot.docs.map(docSnap => (
-          <IncidentRow key={docSnap.id} id={docSnap.id} />
-        ))}
-      </main>
-    </div>
+    <AuthCheck>
+      <div className="min-h-screen bg-white dark:bg-black text-black dark:text-white">
+        <Header />
+        <main className="p-4 max-w-3xl mx-auto">
+          <h1 className="text-2xl mb-4">RTC Admin</h1>
+          {incidentsSnapshot.docs.map(docSnap => (
+            <IncidentRow key={docSnap.id} id={docSnap.id} />
+          ))}
+        </main>
+      </div>
+    </AuthCheck>
   );
 }

--- a/pages/reports/index.tsx
+++ b/pages/reports/index.tsx
@@ -1,0 +1,27 @@
+import { collection } from 'firebase/firestore';
+import { useCollection } from 'react-firebase-hooks/firestore';
+import Header from '@/components/Header';
+import { db } from '@/firebase/client';
+import AuthCheck from '@/components/AuthCheck';
+
+export default function ReportList() {
+  const [snap] = useCollection(collection(db, 'rtc'));
+  return (
+    <AuthCheck>
+      <div className="min-h-screen bg-white dark:bg-black text-black dark:text-white">
+        <Header />
+        <main className="p-4 max-w-3xl mx-auto space-y-2">
+          <h1 className="text-2xl mb-4">All Reports</h1>
+          {!snap && <p>Loading…</p>}
+          {snap && (
+            <ul className="space-y-1 list-disc list-inside">
+              {snap.docs.map(doc => (
+                <li key={doc.id}>{doc.id}</li>
+              ))}
+            </ul>
+          )}
+        </main>
+      </div>
+    </AuthCheck>
+  );
+}


### PR DESCRIPTION
## Summary
- require authentication for `/admin` and new `/reports` page
- implement `AuthCheck` component with Google sign‑in
- secure `firestore.rules` so that admin data requires an authenticated user

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6869a9e2593483248723f8e6b8a66c4b