### PR TITLE
Improve Firestore security

### DIFF
--- a/__tests__/firebase.test.ts
+++ b/__tests__/firebase.test.ts
@@ -18,6 +18,12 @@ jest.mock('firebase/firestore', () => {
   return { __esModule: true, ...mocks };
 });
 
+jest.mock('firebase/auth', () => ({
+  getAuth: jest.fn(() => ({})),
+  signInAnonymously: jest.fn(() => Promise.resolve()),
+  onAuthStateChanged: jest.fn(),
+}));
+
 const REQUIRED = [
   'NEXT_PUBLIC_FIREBASE_API_KEY',
   'NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN',

--- a/components/AuthCheck.tsx
+++ b/components/AuthCheck.tsx
@@ -1,9 +1,9 @@
 import { ReactNode } from 'react';
-import { getAuth, GoogleAuthProvider, signInWithPopup } from 'firebase/auth';
+import { GoogleAuthProvider, signInWithPopup } from 'firebase/auth';
+import { auth } from '@/firebase/client';
 import { useAuthState } from 'react-firebase-hooks/auth';
 
 export default function AuthCheck({ children }: { children: ReactNode }) {
-  const auth = getAuth();
   const [user, loading] = useAuthState(auth);
 
   const signIn = async () => {

--- a/firebase/client.ts
+++ b/firebase/client.ts
@@ -1,6 +1,12 @@
 import { initializeApp, getApp, getApps } from 'firebase/app';
 import { getAnalytics } from 'firebase/analytics';
 import { getFirestore, setLogLevel, type Firestore } from 'firebase/firestore';
+import {
+  getAuth,
+  signInAnonymously,
+  onAuthStateChanged,
+  type Auth,
+} from 'firebase/auth';
 
 const firebaseConfig = {
   apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
@@ -15,6 +21,9 @@ const firebaseConfig = {
 // Initialize firebase only once, even if hot-reloaded
 const app = !getApps().length ? initializeApp(firebaseConfig) : getApp();
 
+// Export auth instance for client usage
+export const auth: Auth = getAuth(app);
+
 // Enable verbose Firestore logs for easier debugging in non-production envs
 if (process.env.NODE_ENV !== 'production') {
   setLogLevel('debug');
@@ -26,3 +35,12 @@ if (typeof window !== 'undefined') {
 }
 
 export const db: Firestore = getFirestore(app);
+
+// Ensure unauthenticated visitors can still read reports
+if (typeof window !== 'undefined') {
+  onAuthStateChanged(auth, user => {
+    if (!user) {
+      signInAnonymously(auth).catch(console.error);
+    }
+  });
+}

--- a/firestore.rules
+++ b/firestore.rules
@@ -2,11 +2,13 @@ rules_version = '2';
 service cloud.firestore {
   match /databases/{db}/documents {
     match /rtc/{id} {
-      // Public read/write access so users can submit and view RTC reports
-      allow read, write: if true;
+      // Anyone signed in (including anonymous) may read or write
+      // collision reports and related party submissions.
+      // Anonymous auth is used for public forms so unauthenticated
+      // visitors must still sign in anonymously before access.
+      allow read, write: if request.auth != null;
       match /submissions/{subId} {
-        // Individual party submissions remain publicly writable
-        allow read, write: if true;
+        allow read, write: if request.auth != null;
       }
     }
 


### PR DESCRIPTION
## Summary
- tighten Firestore rules and require authentication
- sign users in anonymously on the client
- adjust AuthCheck to share the auth instance
- update unit tests for new auth usage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6869b225fa288324b594167df7141048