### PR TITLE
Add build step for Firebase functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ node_modules
 .next
 .env.local
 .DS_Store
+functions/node_modules/
+functions/lib/

--- a/firebase/functions/cleanupExpiredReports.ts
+++ b/firebase/functions/cleanupExpiredReports.ts
@@ -1,4 +1,4 @@
-import * as functions from 'firebase-functions';
+import * as functions from 'firebase-functions/v1';
 import * as admin from 'firebase-admin';
 
 if (!admin.apps.length) {

--- a/firebase/functions/sendEmail.ts
+++ b/firebase/functions/sendEmail.ts
@@ -1,4 +1,4 @@
-import * as functions from 'firebase-functions';
+import * as functions from 'firebase-functions/v1';
 import { Resend } from 'resend';
 
 const resend = new Resend(process.env.RESEND_API_KEY);

--- a/functions/index.js
+++ b/functions/index.js
@@ -1,5 +1,5 @@
-const sendEmail = require('../firebase/functions/sendEmail');
-const cleanupExpiredReports = require('../firebase/functions/cleanupExpiredReports');
+const sendEmail = require('./lib/sendEmail');
+const cleanupExpiredReports = require('./lib/cleanupExpiredReports');
 
 exports.sendEmail = sendEmail.sendEmail;
 exports.cleanupExpiredReports = cleanupExpiredReports.cleanupExpiredReports;

--- a/functions/package.json
+++ b/functions/package.json
@@ -1,9 +1,15 @@
 {
   "name": "functions",
   "main": "index.js",
+  "scripts": {
+    "build": "tsc"
+  },
   "dependencies": {
     "firebase-functions": "^4.3.0",
     "firebase-admin": "^11.10.1",
-    "resend": "^0.3.0"
+    "resend": "^4.6.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.8.3"
   }
 }

--- a/functions/tsconfig.json
+++ b/functions/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "es2017",
+    "module": "commonjs",
+    "lib": ["es2017"],
+    "rootDir": "../firebase/functions",
+    "outDir": "./lib",
+    "esModuleInterop": true,
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "strict": false
+  },
+  "include": ["../firebase/functions/**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- compile Firebase functions TypeScript
- point `functions/index.js` to compiled files
- fix imports after upgrading to functions v1
- ignore build artifacts

## Testing
- `npm test`
- `npm --prefix functions run build`

------
https://chatgpt.com/codex/tasks/task_e_686a5da328648324a1ed6d31f7da47f1